### PR TITLE
Add recently approved events to default newsletter

### DIFF
--- a/app/Modules/Core/Model/Entity/Event.php
+++ b/app/Modules/Core/Model/Entity/Event.php
@@ -64,6 +64,11 @@ final class Event
      */
     private $created;
 
+    /**
+     * @var DateTime
+     */
+    private $approved;
+
     public function __construct(
         ?int $id = null,
         string $name,
@@ -75,7 +80,8 @@ final class Event
         ?string $countryCode = null,
         ?string $image = null,
         ?int $rate = null,
-        ?DateTime $created = null
+        ?DateTime $created = null,
+        ?DateTime $approved = null
     )
     {
         $this->id = $id;
@@ -89,6 +95,7 @@ final class Event
         $this->image = $image;
         $this->rate = $rate;
         $this->created = $created;
+        $this->approved = $approved;
     }
 
     public static function createFromRow(IRow $eventRow): Event
@@ -104,7 +111,8 @@ final class Event
             $eventRow['country_id'],
             $eventRow['image'],
             $eventRow['rate'],
-            $eventRow['created']
+            $eventRow['created'],
+            $eventRow['approved']
         );
     }
 
@@ -200,6 +208,11 @@ final class Event
     public function getCreated(): ?DateTime
     {
         return $this->created;
+    }
+
+    public function getApproved(): ?DateTime
+    {
+        return $this->approved;
     }
 
     public function setRate(int $rate): void

--- a/app/Modules/Core/Model/EventModel.php
+++ b/app/Modules/Core/Model/EventModel.php
@@ -158,18 +158,11 @@ final class EventModel extends AbstractBaseModel
     /**
      * @return Event[]
      */
-    public function getApprovedEventsByDate(
-        DateTime $from,
-        ?DateTime $to = NULL,
-        bool $orderByRate = false
-    ): array
+    public function getApprovedEventsByDate(DateTime $from): array
     {
         $selection = $this->getAll()
             ->where('approved >= ?', $from)
-            ->order($orderByRate ? 'rate DESC, start ASC' : 'start ASC');
-        if ($to) {
-            $selection->where('approved <= ?', $to);
-        }
+            ->order('rate DESC, start ASC');
 
         /** @var Event[] $events */
         $events = [];

--- a/app/Modules/Core/Model/EventModel.php
+++ b/app/Modules/Core/Model/EventModel.php
@@ -154,4 +154,29 @@ final class EventModel extends AbstractBaseModel
             ->order('end DESC')
             ->fetch() ?: null;
     }
+
+    /**
+     * @return Event[]
+     */
+    public function getApprovedEventsByDate(
+        DateTime $from,
+        ?DateTime $to = NULL,
+        bool $orderByRate = false
+    ): array
+    {
+        $selection = $this->getAll()
+            ->where('approved >= ?', $from)
+            ->order($orderByRate ? 'rate DESC, start ASC' : 'start ASC');
+        if ($to) {
+            $selection->where('approved <= ?', $to);
+        }
+
+        /** @var Event[] $events */
+        $events = [];
+        foreach ($selection->fetchAll() as $event) {
+            $events[] = Event::createFromRow($event);
+        }
+
+        return $events;
+    }
 }

--- a/app/Modules/Newsletter/Model/NewsletterService.php
+++ b/app/Modules/Newsletter/Model/NewsletterService.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Newsletter\Model;
 
+use App\Modules\Core\Model\Entity\Event;
 use App\Modules\Core\Model\EventModel;
 use App\Modules\Core\Model\EventTagModel;
 use App\Modules\Core\Model\UserModel;
@@ -9,9 +10,11 @@ use App\Modules\Core\Model\UserTagModel;
 use App\Modules\Core\Utils\DateTime;
 use App\Modules\Newsletter\Model\Entity\Newsletter;
 use BadMethodCallException;
+use DateInterval;
 use Kdyby\Translation\Translator;
 use Nette\Application\LinkGenerator;
 use Nette\Application\UI\ITemplateFactory;
+use Nette\Bridges\ApplicationLatte\ILatteFactory;
 use Nette\Bridges\ApplicationLatte\Template;
 use Nette\Database\Table\IRow;
 use Nette\DI\Container;
@@ -96,6 +99,11 @@ final class NewsletterService
      */
     private $sendGrid;
 
+    /**
+     * @var  ILatteFactory
+     */
+    private $latteFactory;
+
     public function __construct(
         SendGrid $sendGrid,
         LinkGenerator $linkGenerator,
@@ -107,7 +115,8 @@ final class NewsletterService
         UserTagModel $userTagModel,
         UserModel $userModel,
         NewsletterModel $newsletterModel,
-        UserNewsletterModel $userNewsletterModel
+        UserNewsletterModel $userNewsletterModel,
+        ILatteFactory $latteFactory
     ) {
         $this->sendGrid = $sendGrid;
         $this->linkGenerator = $linkGenerator;
@@ -120,6 +129,7 @@ final class NewsletterService
         $this->userModel = $userModel;
         $this->newsletterModel = $newsletterModel;
         $this->userNewsletterModel = $userNewsletterModel;
+        $this->latteFactory = $latteFactory;
     }
 
     public function createDefaultNewsletter(): IRow
@@ -130,7 +140,7 @@ final class NewsletterService
         $newsletter->setSubject($parameters['defaultSubject'] ?? '');
         $newsletter->setFrom($parameters['defaultAuthor']['email'] ?? '');
         $newsletter->setAuthor($parameters['defaultAuthor']['name'] ?? '');
-        $newsletter->setIntroText('');
+        $newsletter->setIntroText($this->renderRecentlyApprovedEvents($this->getApprovedEventsSinceLastNewsletter()));
         $newsletter->setOutroText('');
 
         return $this->newsletterModel->createNewsletter($newsletter);
@@ -306,6 +316,22 @@ final class NewsletterService
     }
 
     /**
+     * Get events approved since 12 hours after last newsletter was created.
+     * @return Event[]
+     */
+    private function getApprovedEventsSinceLastNewsletter(): array
+    {
+        /** @var NetteDateTime $lastNewsletterCreated */
+        $lastNewsletterCreated = $this->newsletterModel->getLatest()['created'];
+
+        return $this->eventModel->getApprovedEventsByDate(
+            $lastNewsletterCreated->add(new DateInterval('PT12H')),
+            null,
+            true
+        );
+    }
+
+    /**
      * Render newsletter content from template (same thing as NewsletterPreseneter:dynamic).
      *
      * @param mixed[] $newsletter
@@ -332,6 +358,35 @@ final class NewsletterService
         // @todo: use latte directly
         return $template->getLatte()->renderToString(
             $template->getFile(), $template->getParameters()
+        );
+    }
+
+    /**
+     * @param Event[] $events
+     */
+    private function renderRecentlyApprovedEvents(array $events): string
+    {
+        $templateFile = __DIR__ . '/../Presenters/templates/Newsletter/newEvents.latte';
+        $latte = $this->latteFactory->create();
+
+        return $latte->renderToString($templateFile, ['events' => $this->mapEventLinksToRedirect($events)]);
+    }
+
+    /**
+     * Map event urls to use Redirect presenter.
+     * @param Event[] $events
+     * @return Event[]
+     */
+    private function mapEventLinksToRedirect(array $events): array
+    {
+        return array_map(
+            function ($event) {
+                /** @var Event $event */
+                $event->setOriginUrl($this->linkGenerator->link('Front:Redirect:', [$event->getOriginUrl()]));
+
+                return $event;
+            },
+            $events
         );
     }
 }

--- a/app/Modules/Newsletter/Model/NewsletterService.php
+++ b/app/Modules/Newsletter/Model/NewsletterService.php
@@ -140,7 +140,11 @@ final class NewsletterService
         $newsletter->setSubject($parameters['defaultSubject'] ?? '');
         $newsletter->setFrom($parameters['defaultAuthor']['email'] ?? '');
         $newsletter->setAuthor($parameters['defaultAuthor']['name'] ?? '');
-        $newsletter->setIntroText($this->renderRecentlyApprovedEvents($this->getApprovedEventsSinceLastNewsletter()));
+        $newsletter->setIntroText(
+            $this->renderRecentlyApprovedEvents(
+                $this->getApprovedEventsSinceLastNewsletter()
+            )
+        );
         $newsletter->setOutroText('');
 
         return $this->newsletterModel->createNewsletter($newsletter);
@@ -325,9 +329,7 @@ final class NewsletterService
         $lastNewsletterCreated = $this->newsletterModel->getLatest()['created'];
 
         return $this->eventModel->getApprovedEventsByDate(
-            $lastNewsletterCreated->add(new DateInterval('PT12H')),
-            null,
-            true
+            $lastNewsletterCreated->add(new DateInterval('PT12H'))
         );
     }
 

--- a/app/lang/newsletter.cs_CZ.neon
+++ b/app/lang/newsletter.cs_CZ.neon
@@ -1,2 +1,3 @@
 unsubscribe.unsubscribed: "No dobrá. My si email <del>%email%</del> zatím škrtáme, ale brzy na viděnou (ツ)"
 email.events.nextWeek: "Příští týden"
+email.events.selectedNewEvents: "Vybrané nové akce"


### PR DESCRIPTION
So far I had to build newsletter intro text html manually (usually contains new events).

Now fresh newsletter from newsletters:create command contains initial html intro with recently approved events ordered by size and start date. You are still able to do adjustments before send, however the process will be much faster.