### PR TITLE
Update coding standard to ECS 2.5

### DIFF
--- a/app/Modules/Core/Model/EventModel.php
+++ b/app/Modules/Core/Model/EventModel.php
@@ -32,6 +32,7 @@ final class EventModel extends AbstractBaseModel
         self::STATE_NOT_APPROVED,
         self::STATE_SKIP,
     ];
+
     /**
      * @var string
      */

--- a/app/Modules/Core/Model/EventSources/Facebook/FacebookEventSource.php
+++ b/app/Modules/Core/Model/EventSources/Facebook/FacebookEventSource.php
@@ -57,6 +57,7 @@ final class FacebookEventSource extends AbstractEventSource
             );
         } catch (FacebookApiException $e) {
             Debugger::log($e, Debugger::EXCEPTION);
+
             throw $e;
         }
     }

--- a/app/Modules/Core/Model/UserModel.php
+++ b/app/Modules/Core/Model/UserModel.php
@@ -24,6 +24,7 @@ final class UserModel extends AbstractBaseModel
      * @var string
      */
     public const ADMIN_LOGIN = 'admin';
+
     /**
      * @var string
      */

--- a/app/Modules/Core/Presenters/AbstractBasePresenter.php
+++ b/app/Modules/Core/Presenters/AbstractBasePresenter.php
@@ -58,6 +58,7 @@ abstract class AbstractBasePresenter extends Presenter
                     'Invalid user token "%s". Can not login.',
                     $token
                 ));
+
                 throw new BadRequestException;
             }
 

--- a/app/Modules/Front/Components/Tags/Tags.php
+++ b/app/Modules/Front/Components/Tags/Tags.php
@@ -19,6 +19,7 @@ final class Tags extends AbstractBaseControl
      * @var callable[]
      */
     public $onChange = [];
+
     /**
      * @var TagModel
      */

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         "contributte/console": "^0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1",
+        "phpunit/phpunit": "^6.4",
         "robmorgan/phinx": "^0.7",
         "phpstan/phpstan": "^0.8",
         "phpstan/phpstan-nette": "^0.8",
-        "symplify/easy-coding-standard": "^2.2"
+        "symplify/easy-coding-standard": "^2.5.5"
     },
     "autoload": {
         "psr-4": {

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -34,16 +34,15 @@ parameters:
         - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
         # strict rule on this code
         - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
+        - Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff
 
     skip:
-        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff:
-            # "todo" notes
-            - app/Modules/Front/Components/Tags/Tags.php
-            - app/Modules/Email/Model/EmailService.php
-            - app/Modules/Newsletter/Model/NewsletterService.php
         SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
             - app/bootstrap.php
         # bug: https://github.com/Symplify/Symplify/issues/395
         Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer:
             - app/Modules/Admin/Components/EventsTable/NotApprovedEventsTableFactoryInterface.php
             - app/Modules/Admin/Components/SourcesTable/SourcesTableFactoryInterface.php
+
+    skip_codes:
+        - SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff.UselessDocComment

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -19,10 +19,6 @@ checkers:
 
     # Type Hints
     SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
-        usefulAnnotations:
-            - @todo
-            - @dataProvider
-            - @throws
         enableEachParameterAndReturnInspection: true
 
     # Namespaces
@@ -36,6 +32,11 @@ parameters:
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
         - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
         - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
+        # mutually excluded
+        - SlevomatCodingStandard\Sniffs\ControlStructures\DisallowYodaComparisonSniff
+        # strict rule on this code
+        - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
+
     skip:
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff:
             # "todo" notes
@@ -44,3 +45,7 @@ parameters:
             - app/Modules/Newsletter/Model/NewsletterService.php
         SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
             - app/bootstrap.php
+        # bug: https://github.com/Symplify/Symplify/issues/395
+        Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer:
+            - app/Modules/Admin/Components/EventsTable/NotApprovedEventsTableFactoryInterface.php
+            - app/Modules/Admin/Components/SourcesTable/SourcesTableFactoryInterface.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -35,14 +35,13 @@ parameters:
         # strict rule on this code
         - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
         - Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff
+        - Symplify\CodingStandard\Sniffs\Property\DynamicPropertySniff
 
     skip:
         SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
             - app/bootstrap.php
-        # bug: https://github.com/Symplify/Symplify/issues/395
-        Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer:
-            - app/Modules/Admin/Components/EventsTable/NotApprovedEventsTableFactoryInterface.php
-            - app/Modules/Admin/Components/SourcesTable/SourcesTableFactoryInterface.php
 
     skip_codes:
         - SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff.UselessDocComment
+        # many todos
+        - PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.DetectedCATCH

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -32,8 +32,6 @@ parameters:
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
         - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
         - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
-        # mutually excluded
-        - SlevomatCodingStandard\Sniffs\ControlStructures\DisallowYodaComparisonSniff
         # strict rule on this code
         - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
 


### PR DESCRIPTION
Hey guys, just small update of coding standard related to ECS, Slevomat, CodeSniffer and PHP CS Fixer, so you don't have to be bothered by them :+1: 