### PR TITLE
fix nette/utils version to 2.4.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "nette/mail": "~2.4",
         "nette/robot-loader": "^2.4|^3.0",
         "nette/security": "~2.4",
-        "nette/utils": "~2.4",
+        "nette/utils": "2.4.9",
         "latte/latte": "~2.4",
         "tracy/tracy": "~2.4",
         "kdyby/translation": "~2.2",


### PR DESCRIPTION
I was redeploying the app and after `composer update` the app stopped working (I couldn't send the newsletter) because of a deprecation error about `Nette\Object` (see [forum](https://forum.nette.org/en/30180-nette-utils-2-5-deprecated-nette-object)). It is used in kdyby/facebook and drahak/restful libraries. Fixes are still not merged.

So I had to downgrade the `nette/utils` lib to 2.4.9 to avoid the error and send the newsletter.

Any other ideas guys? @jakubzaba @TomasVotruba 